### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/hacker5rtj/3b3f08a7-e33f-49d7-8905-0f12c23de876/6f3d53b7-b9dc-4045-8fd6-c314e77ca116/_apis/work/boardbadge/b1950248-6213-4044-8101-59bd379a1ac3)](https://dev.azure.com/hacker5rtj/3b3f08a7-e33f-49d7-8905-0f12c23de876/_boards/board/t/6f3d53b7-b9dc-4045-8fd6-c314e77ca116/Microsoft.RequirementCategory)
 # data-ai
 Azure Data and AI excercises


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/hacker5rtj/3b3f08a7-e33f-49d7-8905-0f12c23de876/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.